### PR TITLE
feat: add role-to-assume input

### DIFF
--- a/download/README.md
+++ b/download/README.md
@@ -180,14 +180,20 @@ This action is a `composite` action.
     # Required: false
     # Default: error
 
+    role-to-assume:
+    # ARN of the role to assume. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
+    #
+    # Required: false
+    # Default: ""
+
     aws-access-key-id:
-    # AWS access key ID of the S3 location
+    # AWS access key ID of the S3 location. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
     #
     # Required: false
     # Default: ""
 
     aws-secret-access-key:
-    # AWS secret access key ID of the S3 location
+    # AWS secret access key ID of the S3 location. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
     #
     # Required: false
     # Default: ""

--- a/download/action.yaml
+++ b/download/action.yaml
@@ -15,12 +15,15 @@ inputs:
     required: false
     description: What to do if the artifact is not found (error, warn, ignore)
     default: error
+  role-to-assume:
+    required: false
+    description: ARN of the role to assume. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
   aws-access-key-id:
     required: false
-    description: AWS access key ID of the S3 location
+    description: AWS access key ID of the S3 location. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
   aws-secret-access-key:
     required: false
-    description: AWS secret access key ID of the S3 location
+    description: AWS secret access key ID of the S3 location. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
   aws-region:
     required: false
     description: AWS region of the S3 location
@@ -37,8 +40,16 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Configure AWS credentials
-      if: inputs.aws-access-key-id != '' && inputs.aws-secret-access-key != ''
+    - name: Configure AWS credentials via OIDC
+      if: inputs.role-to-assume != ''
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-skip-session-tagging: true
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Configure AWS credentials via Access Keys
+      if: inputs.role-to-assume == '' && inputs.aws-access-key-id != '' && inputs.aws-secret-access-key != ''
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}

--- a/upload/README.md
+++ b/upload/README.md
@@ -138,14 +138,20 @@ This action is a `composite` action.
     # Required: false
     # Default: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
 
+    role-to-assume:
+    # ARN of the role to assume. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
+    #
+    # Required: false
+    # Default: ""
+
     aws-access-key-id:
-    # AWS access key ID of the S3 location
+    # AWS access key ID of the S3 location. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
     #
     # Required: false
     # Default: ""
 
     aws-secret-access-key:
-    # AWS secret access key ID of the S3 location
+    # AWS secret access key ID of the S3 location. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
     #
     # Required: false
     # Default: ""

--- a/upload/action.yaml
+++ b/upload/action.yaml
@@ -1,5 +1,6 @@
 name: S3 upload
 description: Upload a set of artifacts to S3
+
 inputs:
   # Path(s) to the artifacts to upload
   path:
@@ -14,12 +15,15 @@ inputs:
     required: false
     description: Artifact key name (a unique hash or timestamp or other identifier)
     default: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+  role-to-assume:
+    required: false
+    description: ARN of the role to assume. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
   aws-access-key-id:
     required: false
-    description: AWS access key ID of the S3 location
+    description: AWS access key ID of the S3 location. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
   aws-secret-access-key:
     required: false
-    description: AWS secret access key ID of the S3 location
+    description: AWS secret access key ID of the S3 location. If no credentials are provided, the action will not try to authenticate with AWS and use any existing environment credentials.
   aws-region:
     required: false
     description: AWS region of the S3 location
@@ -95,13 +99,22 @@ runs:
           echo "folder=$TMPARTIFACT" >> $GITHUB_OUTPUT
         fi
 
-    - name: Configure AWS credentials
-      if: inputs.aws-access-key-id != '' && inputs.aws-secret-access-key != ''
+    - name: Configure AWS credentials via OIDC
+      if: inputs.role-to-assume != ''
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-skip-session-tagging: true
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Configure AWS credentials via Access Keys
+      if: inputs.role-to-assume == '' && inputs.aws-access-key-id != '' && inputs.aws-secret-access-key != ''
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ inputs.aws-region }}
+
     - name: Upload artifact to S3
       id: s3
       shell: bash


### PR DESCRIPTION
**Description**

Add `role-to-assume` input so that we don't have to externally call the aws action.

**Changes**

* feat(gha): move OIDC config to the reusable workflow

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
