### PR TITLE
Add shellcheck and fix download bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,10 @@ repos:
     rev: v1.7.1
     hooks:
       - id: actionlint
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: shellcheck
   - repo: local
     hooks:
       - id: update-action-readme

--- a/download/action.yaml
+++ b/download/action.yaml
@@ -69,7 +69,7 @@ runs:
 
         # S3 URI to download
         S3URI="${{ inputs.s3uri }}"
-        ARTIFACT_NAME="$(basename $S3URI)"
+        ARTIFACT_NAME="$(basename "$S3URI")"
 
         # Try to download and handle failure
         AWSCMD=${AWSCMD:-aws}

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -2,15 +2,15 @@
 
 set -e
 
-for i in $*; do
-  # ignore if the file does not end with /action.yaml
-  if [[ "$i" != *"/action.yaml" ]]; then
-    echo "skipping: ${i}"
-    continue
-  fi
+for i in "$@"; do
+	# ignore if the file does not end with /action.yaml
+	if [[ "$i" != *"/action.yaml" ]]; then
+		echo "skipping: ${i}"
+		continue
+	fi
 
-  echo "npx action-docs --no-banner -s "${i}""
-  cd $(dirname "$i")
-  npx action-docs@2 --no-banner -s action.yaml -u README.md || echo "action-docs failed for $i"
-  cd -
+	echo "npx action-docs --no-banner -s ${i}"
+	cd "$(dirname "$i")"
+	npx action-docs@2 --no-banner -s action.yaml -u README.md || echo "action-docs failed for $i"
+	cd -
 done


### PR DESCRIPTION
**Description**

This PR adds shell check to the action and fixes a bug in the download action.

The bug is that the download action was not wrapping in quotes the S3 uri, making it fail when the path had spaces.

We can't yet lint the actual actions since it's not supported by actionlint yet. See https://github.com/rhysd/actionlint/issues/46

**Changes**

* ci: use renovate, update CI and precommit and automate docs
* fix(download): wrap S3 uri in quotes

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
